### PR TITLE
Add exim_relay_relay_protocol variable for SMTPS (implicit TLS) support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,7 +111,11 @@ exim_relay_dkim_privkey_contents: ""
 
 exim_relay_relay_use: false
 exim_relay_relay_host_name: "mail.example.com"
-exim_relay_relay_host_port: 587
+# Supported values: "smtp" (STARTTLS, default) or "smtps" (implicit TLS on port 465, RFC 8314)
+exim_relay_relay_protocol: "smtp"
+# When using "smtps", port 465 is set automatically; 587 is the default for "smtp".
+# You can override this explicitly if your provider uses a non-standard port.
+exim_relay_relay_host_port: "{{ '465' if exim_relay_relay_protocol == 'smtps' else '587' }}"
 exim_relay_relay_auth: false
 exim_relay_relay_auth_username: ""
 exim_relay_relay_auth_password: ""

--- a/docs/configuring-exim-relay.md
+++ b/docs/configuring-exim-relay.md
@@ -96,7 +96,24 @@ exim_relay_relay_auth_username: "another.sender@example.com"
 exim_relay_relay_auth_password: "PASSWORD_FOR_THE_RELAY_HERE"
 ```
 
-**Note**: only the secure submission protocol (using `STARTTLS`, usually on port `587`) is supported. **SMTPS** (encrypted SMTP, usually on port `465`) **is not supported**.
+By default, STARTTLS on port 587 is used. To use implicit TLS (SMTPS) on port 465 instead, see [the section below](#using-smtps-implicit-tls-on-port-465).
+
+### Using SMTPS (implicit TLS on port 465)
+
+Some providers require implicit TLS ([RFC 8314](https://www.rfc-editor.org/rfc/rfc8314)) instead of STARTTLS. Set `exim_relay_relay_protocol` to `smtps` — the port defaults to `465` automatically:
+
+```yaml
+exim_relay_sender_address: "another.sender@example.com"
+exim_relay_relay_use: true
+exim_relay_relay_host_name: "mail.example.com"
+exim_relay_relay_protocol: "smtps"
+exim_relay_relay_auth: true
+exim_relay_relay_auth_username: "another.sender@example.com"
+exim_relay_relay_auth_password: "PASSWORD_FOR_THE_RELAY_HERE"
+```
+
+> [!NOTE]
+> Port 465 is set automatically when `exim_relay_relay_protocol: "smtps"` is used. You can still override `exim_relay_relay_host_port` explicitly if your provider uses a non-standard port.
 
 ## Installing
 

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -6,6 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 {% if exim_relay_relay_use %}
 SMARTHOST={{ exim_relay_relay_host_name }}::{{ exim_relay_relay_host_port }}
+SMARTHOST_PROTOCOL={{ exim_relay_relay_protocol }}
 {% endif %}
 {% if exim_relay_relay_auth %}
 SMTP_USERNAME={{ exim_relay_relay_auth_username }}


### PR DESCRIPTION
Introduce exim_relay_relay_protocol to allow choosing between STARTTLS (smtp, default) and implicit TLS on port 465 (smtps, RFC 8314) when connecting to a smarthost. The relay port defaults to 465 when smtps is used and to 587 otherwise, but can still be overridden explicitly.

Requires devture/exim-relay#24.

* Closes #16 